### PR TITLE
fix(back): #2 initial db schema

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,5 +1,5 @@
-CREATE TABLE Persons (
-    person_id UNIQUEIDENTIFIER DEFAULT NEWSEQUENTIALID() PRIMARY KEY,
+CREATE TABLE Users (
+    user_id UNIQUEIDENTIFIER DEFAULT NEWSEQUENTIALID() PRIMARY KEY,
     name NVARCHAR(100) NOT NULL,
     last_name NVARCHAR(100) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
@@ -16,8 +16,8 @@ CREATE TABLE Accounts (
     balance MONEY NOT NULL CHECK (balance >= 0),
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
-    person_id UNIQUEIDENTIFIER NOT NULL,
-    FOREIGN KEY (person_id) REFERENCES Persons(person_id)
+    user_id UNIQUEIDENTIFIER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES Users(user_id)
 );
 
 CREATE TABLE Categories (
@@ -31,7 +31,6 @@ CREATE TABLE Categories (
 
 CREATE TABLE FinancialTransactions (
     transaction_id UNIQUEIDENTIFIER DEFAULT NEWSEQUENTIALID() PRIMARY KEY,
-    type TINYINT NOT NULL,
     value MONEY NOT NULL CHECK (value >= 0),
     description VARCHAR(500),
     date DATETIME NOT NULL,
@@ -55,9 +54,10 @@ CREATE TABLE RecurrentTransactions (
     updated_at DATETIME NOT NULL,
     account_id UNIQUEIDENTIFIER NOT NULL,
     category_id UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT chk_recurrent_transactions_custom_frequency_positive CHECK (custom_frequency IS NULL OR custom_frequency > 0),
     FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
     FOREIGN KEY (category_id) REFERENCES Categories(category_id),
-    CONSTRAINT chk_dates CHECK (end_date IS NULL OR end_date >= initial_date)
+    CONSTRAINT chk_recurrent_transactions_dates CHECK (end_date IS NULL OR end_date >= initial_date)
 );
 
 CREATE TABLE LiquidityProjections (
@@ -88,7 +88,33 @@ CREATE TABLE UserAccesses (
     role TINYINT NOT NULL,
     created_at DATETIME NOT NULL,
     account_id UNIQUEIDENTIFIER NOT NULL,
-    person_id UNIQUEIDENTIFIER NOT NULL,
+    user_id UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT uq_user_accesses_account_user UNIQUE (account_id, user_id),
     FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
-    FOREIGN KEY (person_id) REFERENCES Persons(person_id)
+    FOREIGN KEY (user_id) REFERENCES Users(user_id)
 );
+
+CREATE INDEX ix_users_last_name_name ON Users(last_name, name);
+CREATE INDEX ix_users_active ON Users(active);
+
+CREATE INDEX ix_accounts_user_id ON Accounts(user_id);
+CREATE INDEX ix_accounts_account_type ON Accounts(account_type);
+
+CREATE INDEX ix_categories_type ON Categories(type);
+
+CREATE INDEX ix_financial_transactions_account_id_date ON FinancialTransactions(account_id, date DESC);
+CREATE INDEX ix_financial_transactions_category_id_date ON FinancialTransactions(category_id, date DESC);
+CREATE INDEX ix_financial_transactions_status_date ON FinancialTransactions(status, date DESC);
+
+CREATE INDEX ix_recurrent_transactions_account_id_initial_date ON RecurrentTransactions(account_id, initial_date);
+CREATE INDEX ix_recurrent_transactions_category_id ON RecurrentTransactions(category_id);
+CREATE INDEX ix_recurrent_transactions_end_date ON RecurrentTransactions(end_date);
+
+CREATE INDEX ix_liquidity_projections_account_id_projection_date ON LiquidityProjections(account_id, projection_date);
+CREATE INDEX ix_liquidity_projections_calculation_date ON LiquidityProjections(calculation_date);
+
+CREATE INDEX ix_alerts_liquidity_projection_id ON Alerts(liquidity_projection_id);
+CREATE INDEX ix_alerts_status_date ON Alerts(status, date);
+CREATE INDEX ix_alerts_type_date ON Alerts(type, date);
+
+CREATE INDEX ix_user_accesses_user_id ON UserAccesses(user_id);


### PR DESCRIPTION
### Descripcion

Se ajusta el schema inicial de base de datos para que quede alineado con el modelo actual de la aplicacion. La migracion `V1__init.sql` renombra la entidad principal de `Persons` a `Users` y actualiza sus llaves foraneas en `Accounts` y `UserAccesses`, elimina la columna `type` de `FinancialTransactions`, agrega restricciones explicitas para `RecurrentTransactions` y evita duplicados en `UserAccesses` con una llave unica compuesta.

Adicionalmente, se incorporan indices sobre columnas y combinaciones de consulta frecuentes en usuarios, cuentas, transacciones, proyecciones, alertas y accesos para mejorar el acceso a datos desde el esquema inicial.

### Como reproducir el cambio

1. Levante una base de datos vacia y ejecute la migracion inicial de esta rama (`V1__init.sql`) usando el flujo normal del proyecto.
2. Verifique que se creen las tablas `Users`, `Accounts`, `Categories`, `FinancialTransactions`, `RecurrentTransactions`, `LiquidityProjections`, `Alerts` y `UserAccesses`.
3. Confirme que `Accounts.user_id` y `UserAccesses.user_id` referencien `Users(user_id)`, y que ya no existan referencias a `Persons` o `person_id`.
4. Revise la estructura de `FinancialTransactions` y valide que no incluya la columna `type`.
5. Valide en `RecurrentTransactions` que exista la restriccion para `custom_frequency > 0` cuando tenga valor y que `end_date` no pueda ser menor que `initial_date`.
6. Confirme que `UserAccesses` tenga la restriccion unica compuesta sobre `(account_id, user_id)` y que los indices nuevos hayan sido creados correctamente.

### Evidencia

N/A

### Criterios

- [x] Revise los cambios subidos
- [x] Probe los cambios antes de subir el cambio
- [ ] Revise el performance (n+1, consultas, etc) antes de subir el cambio
- [ ] Agregue/ajuste los tests si aplica
- [ ] Agregue/ajuste la documentacion si aplica