### PR TITLE
feat(back): #23 authentication and roles management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <!-- JDBC básico -->
         <dependency>
@@ -64,6 +68,10 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-sqlserver</artifactId>
+        </dependency>
 
         <!-- Documentación con OpenAPI/Swagger -->
         <dependency>
@@ -71,45 +79,46 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
 
-        <!-- Testing base con exclusiones -->
+        <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy-agent</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
-        <!-- Mockito actualizado (Java 25 soportado) -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Byte Buddy actualizado -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.17.5</version>
-            <scope>test</scope>
         </dependency>
-
-        <!-- Byte Buddy Agent actualizado -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>

--- a/src/main/java/com/cajaviva/cajaviva/CajaVivaApplication.java
+++ b/src/main/java/com/cajaviva/cajaviva/CajaVivaApplication.java
@@ -13,6 +13,3 @@ public class CajaVivaApplication {
 
 
 }
-
-
-

--- a/src/main/java/com/cajaviva/cajaviva/auth/config/CookieProperties.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/config/CookieProperties.java
@@ -1,0 +1,44 @@
+package com.cajaviva.cajaviva.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.cookie")
+public class CookieProperties {
+
+    private String domain;
+    private boolean secure;
+    private String sameSite = "Lax";
+    private String path = "/";
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    public String getSameSite() {
+        return sameSite;
+    }
+
+    public void setSameSite(String sameSite) {
+        this.sameSite = sameSite;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/config/JwtProperties.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/config/JwtProperties.java
@@ -1,0 +1,53 @@
+package com.cajaviva.cajaviva.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.jwt")
+public class JwtProperties {
+
+    private String issuer;
+    private String audience;
+    private long accessTtlMinutes;
+    private long refreshTtlDays;
+    private String signingKey;
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public void setAudience(String audience) {
+        this.audience = audience;
+    }
+
+    public long getAccessTtlMinutes() {
+        return accessTtlMinutes;
+    }
+
+    public void setAccessTtlMinutes(long accessTtlMinutes) {
+        this.accessTtlMinutes = accessTtlMinutes;
+    }
+
+    public long getRefreshTtlDays() {
+        return refreshTtlDays;
+    }
+
+    public void setRefreshTtlDays(long refreshTtlDays) {
+        this.refreshTtlDays = refreshTtlDays;
+    }
+
+    public String getSigningKey() {
+        return signingKey;
+    }
+
+    public void setSigningKey(String signingKey) {
+        this.signingKey = signingKey;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/controller/AuthController.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/controller/AuthController.java
@@ -1,0 +1,97 @@
+package com.cajaviva.cajaviva.auth.controller;
+
+import com.cajaviva.cajaviva.auth.dto.AuthResponse;
+import com.cajaviva.cajaviva.auth.dto.LoginRequest;
+import com.cajaviva.cajaviva.auth.security.UserPrincipal;
+import com.cajaviva.cajaviva.auth.service.AuthService;
+import com.cajaviva.cajaviva.auth.service.CookieService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "Authentication", description = "Flujo de autenticación por cookies: login emite CV_ACCESS_TOKEN y CV_REFRESH_TOKEN. Usa /auth/refresh para renovar sesión y /auth/logout para invalidarla.")
+public class AuthController {
+
+    private final AuthService authService;
+    private final CookieService cookieService;
+
+    public AuthController(AuthService authService, CookieService cookieService) {
+        this.authService = authService;
+        this.cookieService = cookieService;
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "Login", description = "Autentica usuario y retorna cookies seguras HttpOnly con access y refresh token.", security = {})
+    @ApiResponse(responseCode = "200", description = "Autenticación exitosa", content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+    @ApiResponse(responseCode = "401", description = "Credenciales inválidas")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+        AuthService.AuthResult result = authService.login(request);
+        cookieService.addAccessCookie(response, result.accessToken(), authService.accessTtl());
+        cookieService.addRefreshCookie(response, result.refreshToken(), authService.refreshTtl());
+        return ResponseEntity.ok(result.response());
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "Refresh", description = "Rota refresh token y emite nueva sesión.", security = {})
+    @ApiResponse(responseCode = "200", description = "Refresh exitoso", content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+    @ApiResponse(responseCode = "401", description = "Refresh inválido")
+    public ResponseEntity<AuthResponse> refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = readCookie(request, CookieService.REFRESH_COOKIE);
+        AuthService.AuthResult result = authService.refresh(refreshToken);
+        cookieService.addAccessCookie(response, result.accessToken(), authService.accessTtl());
+        cookieService.addRefreshCookie(response, result.refreshToken(), authService.refreshTtl());
+        return ResponseEntity.ok(result.response());
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Logout", description = "Revoca sesión y limpia cookies de autenticación.", security = {})
+    @ApiResponse(responseCode = "200", description = "Logout exitoso")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = readCookie(request, CookieService.REFRESH_COOKIE);
+        authService.logout(refreshToken);
+        cookieService.clearAuthCookies(response);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    @Operation(
+            summary = "Sesión actual",
+            description = "Retorna la identidad autenticada actual.",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponse(responseCode = "200", description = "Usuario autenticado")
+    @ApiResponse(responseCode = "401", description = "No autenticado")
+    public ResponseEntity<AuthResponse> me(@AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(authService.me(principal.getUserId()));
+    }
+
+    private String readCookie(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookieName.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/dto/AuthResponse.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/dto/AuthResponse.java
@@ -1,0 +1,13 @@
+package com.cajaviva.cajaviva.auth.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record AuthResponse(
+        UUID userId,
+        String email,
+        List<String> roles,
+        LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/dto/LoginRequest.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.cajaviva.cajaviva.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email @NotBlank String email,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.cajaviva.cajaviva.auth.security;
+
+import com.cajaviva.cajaviva.auth.service.CookieService;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = readCookie(request, CookieService.ACCESS_COOKIE);
+
+        if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            try {
+                Claims claims = jwtService.parseAndValidate(token);
+                if (jwtService.extractTokenType(claims) == JwtService.TokenType.ACCESS) {
+                    UUID userId = UUID.fromString(claims.getSubject());
+                    String email = String.valueOf(claims.get("email"));
+                    UserPrincipal principal = new UserPrincipal(userId, email, true);
+                    UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                            principal,
+                            null,
+                            principal.getAuthorities()
+                    );
+                    auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (Exception ignored) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String readCookie(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookieName.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/security/RestAccessDeniedHandler.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/security/RestAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.cajaviva.cajaviva.auth.security;
+
+import com.cajaviva.cajaviva.exception.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ApiErrorResponse error = new ApiErrorResponse("No autorizado.", "FORBIDDEN", LocalDateTime.now());
+        objectMapper.writeValue(response.getOutputStream(), error);
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.cajaviva.cajaviva.auth.security;
+
+import com.cajaviva.cajaviva.exception.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ApiErrorResponse error = new ApiErrorResponse("No autenticado.", "UNAUTHORIZED", LocalDateTime.now());
+        objectMapper.writeValue(response.getOutputStream(), error);
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/security/UserPrincipal.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/security/UserPrincipal.java
@@ -1,0 +1,61 @@
+package com.cajaviva.cajaviva.auth.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public class UserPrincipal implements UserDetails {
+
+    private final UUID userId;
+    private final String email;
+    private final boolean active;
+
+    public UserPrincipal(UUID userId, String email, boolean active) {
+        this.userId = userId;
+        this.email = email;
+        this.active = active;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return active;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/service/AuthService.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/service/AuthService.java
@@ -1,0 +1,121 @@
+package com.cajaviva.cajaviva.auth.service;
+
+import com.cajaviva.cajaviva.auth.config.JwtProperties;
+import com.cajaviva.cajaviva.auth.dto.AuthResponse;
+import com.cajaviva.cajaviva.auth.dto.LoginRequest;
+import com.cajaviva.cajaviva.entity.AuthUser;
+import com.cajaviva.cajaviva.entity.RefreshToken;
+import com.cajaviva.cajaviva.exception.AuthenticationFailedException;
+import com.cajaviva.cajaviva.exception.BusinessValidationException;
+import com.cajaviva.cajaviva.repository.JPA.AuthUserRepository;
+import io.jsonwebtoken.Claims;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class AuthService {
+
+    private final AuthUserRepository authUserRepository;
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProperties jwtProperties;
+
+    public AuthService(
+            AuthUserRepository authUserRepository,
+            JwtService jwtService,
+            RefreshTokenService refreshTokenService,
+            PasswordEncoder passwordEncoder,
+            JwtProperties jwtProperties
+    ) {
+        this.authUserRepository = authUserRepository;
+        this.jwtService = jwtService;
+        this.refreshTokenService = refreshTokenService;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProperties = jwtProperties;
+    }
+
+    public AuthResult login(LoginRequest request) {
+        AuthUser user = authUserRepository.findByEmailIgnoreCase(request.email())
+                .orElseThrow(() -> new AuthenticationFailedException("Credenciales invalidas."));
+        if (!user.isActive() || !passwordEncoder.matches(request.password(), user.getPasswordDigest())) {
+            throw new AuthenticationFailedException("Credenciales invalidas.");
+        }
+        return issueTokens(user);
+    }
+
+    public AuthResult refresh(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new AuthenticationFailedException("Refresh token invalido.");
+        }
+        Claims claims;
+        try {
+            claims = jwtService.parseAndValidate(refreshToken);
+        } catch (Exception ex) {
+            throw new AuthenticationFailedException("Refresh token invalido.");
+        }
+        if (jwtService.extractTokenType(claims) != JwtService.TokenType.REFRESH) {
+            throw new AuthenticationFailedException("Token invalido.");
+        }
+
+        RefreshToken stored = refreshTokenService.findByRawToken(refreshToken)
+                .orElseThrow(() -> new AuthenticationFailedException("Refresh token invalido."));
+        if (!refreshTokenService.isUsable(stored)) {
+            throw new AuthenticationFailedException("Refresh token expirado o revocado.");
+        }
+
+        UUID userId = UUID.fromString(claims.getSubject());
+        AuthUser user = authUserRepository.findById(userId)
+                .orElseThrow(() -> new BusinessValidationException("Usuario no encontrado."));
+
+        AuthResult result = issueTokens(user);
+        refreshTokenService.revoke(stored, result.refreshToken());
+        return result;
+    }
+
+    public void logout(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return;
+        }
+        refreshTokenService.findByRawToken(refreshToken).ifPresent(rt -> refreshTokenService.revoke(rt, null));
+    }
+
+    public AuthResponse me(UUID userId) {
+        AuthUser user = authUserRepository.findById(userId)
+                .orElseThrow(() -> new BusinessValidationException("Usuario no encontrado."));
+        return toResponse(user);
+    }
+
+    private AuthResult issueTokens(AuthUser user) {
+        String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtService.generateRefreshToken(user.getId());
+        LocalDateTime accessExpiresAt = LocalDateTime.now().plusMinutes(jwtProperties.getAccessTtlMinutes());
+        LocalDateTime refreshExpiresAt = LocalDateTime.now().plusDays(jwtProperties.getRefreshTtlDays());
+        refreshTokenService.save(user.getId(), refreshToken, refreshExpiresAt);
+        return new AuthResult(accessToken, refreshToken, toResponse(user, accessExpiresAt));
+    }
+
+    private AuthResponse toResponse(AuthUser user) {
+        return toResponse(user, LocalDateTime.now().plusMinutes(jwtProperties.getAccessTtlMinutes()));
+    }
+
+    private AuthResponse toResponse(AuthUser user, LocalDateTime expiresAt) {
+        return new AuthResponse(user.getId(), user.getEmail(), List.of("ROLE_USER"), expiresAt);
+    }
+
+    public Duration accessTtl() {
+        return Duration.ofMinutes(jwtProperties.getAccessTtlMinutes());
+    }
+
+    public Duration refreshTtl() {
+        return Duration.ofDays(jwtProperties.getRefreshTtlDays());
+    }
+
+    public record AuthResult(String accessToken, String refreshToken, AuthResponse response) {
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/service/CookieService.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/service/CookieService.java
@@ -1,0 +1,50 @@
+package com.cajaviva.cajaviva.auth.service;
+
+import com.cajaviva.cajaviva.auth.config.CookieProperties;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+public class CookieService {
+
+    public static final String ACCESS_COOKIE = "CV_ACCESS_TOKEN";
+    public static final String REFRESH_COOKIE = "CV_REFRESH_TOKEN";
+
+    private final CookieProperties cookieProperties;
+
+    public CookieService(CookieProperties cookieProperties) {
+        this.cookieProperties = cookieProperties;
+    }
+
+    public void addAccessCookie(HttpServletResponse response, String token, Duration ttl) {
+        addCookie(response, ACCESS_COOKIE, token, ttl);
+    }
+
+    public void addRefreshCookie(HttpServletResponse response, String token, Duration ttl) {
+        addCookie(response, REFRESH_COOKIE, token, ttl);
+    }
+
+    public void clearAuthCookies(HttpServletResponse response) {
+        addCookie(response, ACCESS_COOKIE, "", Duration.ZERO);
+        addCookie(response, REFRESH_COOKIE, "", Duration.ZERO);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, Duration ttl) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .sameSite(cookieProperties.getSameSite())
+                .path(cookieProperties.getPath())
+                .maxAge(ttl);
+
+        if (cookieProperties.getDomain() != null && !cookieProperties.getDomain().isBlank()) {
+            builder.domain(cookieProperties.getDomain());
+        }
+
+        response.addHeader(HttpHeaders.SET_COOKIE, builder.build().toString());
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/service/JwtService.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/service/JwtService.java
@@ -1,0 +1,68 @@
+package com.cajaviva.cajaviva.auth.service;
+
+import com.cajaviva.cajaviva.auth.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+public class JwtService {
+
+    public enum TokenType { ACCESS, REFRESH }
+
+    private final JwtProperties properties;
+    private final SecretKey secretKey;
+
+    public JwtService(JwtProperties properties) {
+        this.properties = properties;
+        this.secretKey = Keys.hmacShaKeyFor(properties.getSigningKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(UUID userId, String email) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .claim("type", TokenType.ACCESS.name())
+                .issuer(properties.getIssuer())
+                .audience().add(properties.getAudience()).and()
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(properties.getAccessTtlMinutes(), ChronoUnit.MINUTES)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(UUID userId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("type", TokenType.REFRESH.name())
+                .issuer(properties.getIssuer())
+                .audience().add(properties.getAudience()).and()
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(properties.getRefreshTtlDays(), ChronoUnit.DAYS)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims parseAndValidate(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .requireIssuer(properties.getIssuer())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public TokenType extractTokenType(Claims claims) {
+        return TokenType.valueOf(String.valueOf(claims.get("type")));
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/cajaviva/cajaviva/auth/service/RefreshTokenService.java
@@ -1,0 +1,62 @@
+package com.cajaviva.cajaviva.auth.service;
+
+import com.cajaviva.cajaviva.entity.RefreshToken;
+import com.cajaviva.cajaviva.repository.JPA.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    public RefreshToken save(UUID userId, String rawToken, LocalDateTime expiresAt) {
+        RefreshToken token = new RefreshToken();
+        token.setUserId(userId);
+        token.setTokenHash(hash(rawToken));
+        token.setExpiresAt(expiresAt);
+        token.setCreatedAt(LocalDateTime.now());
+        return refreshTokenRepository.save(token);
+    }
+
+    public Optional<RefreshToken> findByRawToken(String rawToken) {
+        return refreshTokenRepository.findByTokenHash(hash(rawToken));
+    }
+
+    public void revoke(RefreshToken token, String replacedByRawToken) {
+        token.setRevokedAt(LocalDateTime.now());
+        if (replacedByRawToken != null) {
+            token.setReplacedByTokenHash(hash(replacedByRawToken));
+        }
+        refreshTokenRepository.save(token);
+    }
+
+    public void revokeAllByUserId(UUID userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    public boolean isUsable(RefreshToken token) {
+        return token.getRevokedAt() == null && token.getExpiresAt().isAfter(LocalDateTime.now());
+    }
+
+    private String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/config/OpenApiConfig.java
+++ b/src/main/java/com/cajaviva/cajaviva/config/OpenApiConfig.java
@@ -1,8 +1,10 @@
 package com.cajaviva.cajaviva.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,9 +17,28 @@ public class OpenApiConfig {
                 .info(new Info()
                         .title("Caja Viva API")
                         .version("1.0")
-                        .description("API para gestión financiera")
+                        .description("""
+                                API para gestion financiera.
+
+                                Flujo de autenticacion:
+                                1. Invoca POST /auth/login con email y password.
+                                2. El backend responde con Set-Cookie para CV_ACCESS_TOKEN y CV_REFRESH_TOKEN.
+                                3. Usa endpoints protegidos enviando cookies automaticamente.
+                                4. Cuando expire el access token, invoca POST /auth/refresh.
+                                5. Para cerrar sesion invoca POST /auth/logout.
+
+                                Para operaciones mutables (POST/PUT/PATCH/DELETE) envia CSRF token (header X-XSRF-TOKEN).
+                                En Swagger UI o escenarios cross-origin puede requerirse withCredentials y CORS compatible con cookies.
+                                """)
                         .contact(new Contact()
                                 .name("Equipo Caja Viva")
-                                .email("soporte@cajaviva.com")));
+                                .email("soporte@cajaviva.com")))
+                .schemaRequirement("cookieAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.COOKIE)
+                                .name("CV_ACCESS_TOKEN")
+                                .description("Cookie HttpOnly con JWT de acceso"))
+                .addSecurityItem(new SecurityRequirement().addList("cookieAuth"));
     }
 }

--- a/src/main/java/com/cajaviva/cajaviva/config/SecurityConfig.java
+++ b/src/main/java/com/cajaviva/cajaviva/config/SecurityConfig.java
@@ -1,0 +1,100 @@
+package com.cajaviva.cajaviva.config;
+
+import com.cajaviva.cajaviva.auth.config.CookieProperties;
+import com.cajaviva.cajaviva.auth.config.JwtProperties;
+import com.cajaviva.cajaviva.auth.security.JwtAuthenticationFilter;
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableMethodSecurity
+@EnableConfigurationProperties({JwtProperties.class, CookieProperties.class})
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+    private final RestAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            RestAuthenticationEntryPoint authenticationEntryPoint,
+            RestAccessDeniedHandler accessDeniedHandler
+    ) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        csrfTokenRepository.setCookiePath("/");
+
+        http
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(Customizer.withDefaults())
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(csrfTokenRepository)
+                        .ignoringRequestMatchers(
+                                new AntPathRequestMatcher("/auth/**", "POST"),
+                                new AntPathRequestMatcher("/registries/users", "POST")
+                        )
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/registries/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
+                        .requestMatchers("/auth/login", "/auth/refresh", "/auth/logout").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/error").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/controller/RegistryController.java
+++ b/src/main/java/com/cajaviva/cajaviva/controller/RegistryController.java
@@ -1,0 +1,44 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.dto.RegisterUserRequest;
+import com.cajaviva.cajaviva.entity.User;
+import com.cajaviva.cajaviva.service.RegistryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/registries")
+@Tag(name = "Registry", description = "Registro publico de usuarios")
+public class RegistryController {
+
+    private final RegistryService registryService;
+
+    public RegistryController(RegistryService registryService) {
+        this.registryService = registryService;
+    }
+
+    @PostMapping("/users")
+    @Operation(
+            summary = "Registrar nuevo usuario",
+            description = "Crea un usuario para autenticacion futura.",
+            security = {}
+    )
+    @ApiResponse(responseCode = "201", description = "Usuario registrado", content = @Content(schema = @Schema(implementation = User.class)))
+    @ApiResponse(responseCode = "400", description = "Request invalido")
+    @ApiResponse(responseCode = "409", description = "Email ya existe")
+    public ResponseEntity<User> register(@Valid @RequestBody RegisterUserRequest request) {
+        User created = registryService.registerUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/controller/UserAccessController.java
+++ b/src/main/java/com/cajaviva/cajaviva/controller/UserAccessController.java
@@ -48,7 +48,7 @@ public class UserAccessController {
         description = "Crea un nuevo UserAccess",
         requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
             content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = UserAccess.class),
-            examples = { @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\n  \"personId\": \"...\", \"accountId\": \"...\", \"role\": \"MANAGER\", \"userId\": \"...\"\n}") })
+            examples = { @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\n  \"accountId\": \"...\", \"role\": 1, \"userId\": \"...\"\n}") })
         ),
         responses = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Creado",
@@ -85,7 +85,7 @@ public class UserAccessController {
         },
         requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
             content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = UserAccess.class),
-            examples = { @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\n  \"personId\": \"...\", \"accountId\": \"...\", \"role\": \"OWNER\", \"userId\": \"...\"\n}") })
+            examples = { @io.swagger.v3.oas.annotations.media.ExampleObject(value = "{\n  \"accountId\": \"...\", \"role\": 2, \"userId\": \"...\"\n}") })
         ),
         responses = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Actualizado",

--- a/src/main/java/com/cajaviva/cajaviva/dao/impl/UserDaoImpl.java
+++ b/src/main/java/com/cajaviva/cajaviva/dao/impl/UserDaoImpl.java
@@ -23,7 +23,7 @@ public class UserDaoImpl implements UserDao {
     public List<User> findAll() {
 
         List<User> users = new ArrayList<>();
-        String sql = "SELECT id, name, email FROM users";
+        String sql = "SELECT id, name, last_name, email, active, password_digest, created_at, updated_at FROM users";
 
         try (
                 Connection conn = conexion.obtenerConexion();
@@ -35,7 +35,18 @@ public class UserDaoImpl implements UserDao {
                 User user = new User();
                 user.setId(UUID.fromString(rs.getString("id")));
                 user.setName(rs.getString("name"));
+                user.setLastName(rs.getString("last_name"));
                 user.setEmail(rs.getString("email"));
+                user.setActive(rs.getBoolean("active"));
+                user.setPasswordDigest(rs.getString("password_digest"));
+                Timestamp createdAt = rs.getTimestamp("created_at");
+                if (createdAt != null) {
+                    user.setCreatedAt(createdAt.toLocalDateTime());
+                }
+                Timestamp updatedAt = rs.getTimestamp("updated_at");
+                if (updatedAt != null) {
+                    user.setUpdatedAt(updatedAt.toLocalDateTime());
+                }
                 users.add(user);
             }
 
@@ -49,7 +60,7 @@ public class UserDaoImpl implements UserDao {
     @Override
     public User findById(UUID id) {
 
-        String sql = "SELECT id, name, email FROM users WHERE id = ?";
+        String sql = "SELECT id, name, last_name, email, active, password_digest, created_at, updated_at FROM users WHERE id = ?";
 
         try (
                 Connection conn = conexion.obtenerConexion();
@@ -64,7 +75,18 @@ public class UserDaoImpl implements UserDao {
                     User user = new User();
                     user.setId(UUID.fromString(rs.getString("id")));
                     user.setName(rs.getString("name"));
+                    user.setLastName(rs.getString("last_name"));
                     user.setEmail(rs.getString("email"));
+                    user.setActive(rs.getBoolean("active"));
+                    user.setPasswordDigest(rs.getString("password_digest"));
+                    Timestamp createdAt = rs.getTimestamp("created_at");
+                    if (createdAt != null) {
+                        user.setCreatedAt(createdAt.toLocalDateTime());
+                    }
+                    Timestamp updatedAt = rs.getTimestamp("updated_at");
+                    if (updatedAt != null) {
+                        user.setUpdatedAt(updatedAt.toLocalDateTime());
+                    }
                     return user;
                 }
             }
@@ -79,7 +101,7 @@ public class UserDaoImpl implements UserDao {
     @Override
     public User create(User user) {
 
-        String sql = "INSERT INTO users (id, name, email) VALUES (?, ?, ?)";
+        String sql = "INSERT INTO users (id, name, last_name, email, active, password_digest, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
         if (user.getId() == null) {
             user.setId(UUID.randomUUID());
@@ -92,7 +114,12 @@ public class UserDaoImpl implements UserDao {
 
             stmt.setString(1, user.getId().toString());
             stmt.setString(2, user.getName());
-            stmt.setString(3, user.getEmail());
+            stmt.setString(3, user.getLastName());
+            stmt.setString(4, user.getEmail());
+            stmt.setBoolean(5, user.isActive());
+            stmt.setString(6, user.getPasswordDigest());
+            stmt.setTimestamp(7, Timestamp.valueOf(user.getCreatedAt()));
+            stmt.setTimestamp(8, Timestamp.valueOf(user.getUpdatedAt()));
 
             stmt.executeUpdate();
 
@@ -106,7 +133,7 @@ public class UserDaoImpl implements UserDao {
     @Override
     public User update(UUID id, User user) {
 
-        String sql = "UPDATE users SET name = ?, email = ? WHERE id = ?";
+        String sql = "UPDATE users SET name = ?, last_name = ?, email = ?, active = ?, password_digest = ?, updated_at = ? WHERE id = ?";
 
         try (
                 Connection conn = conexion.obtenerConexion();
@@ -114,8 +141,12 @@ public class UserDaoImpl implements UserDao {
         ) {
 
             stmt.setString(1, user.getName());
-            stmt.setString(2, user.getEmail());
-            stmt.setString(3, id.toString());
+            stmt.setString(2, user.getLastName());
+            stmt.setString(3, user.getEmail());
+            stmt.setBoolean(4, user.isActive());
+            stmt.setString(5, user.getPasswordDigest());
+            stmt.setTimestamp(6, Timestamp.valueOf(user.getUpdatedAt()));
+            stmt.setString(7, id.toString());
 
             stmt.executeUpdate();
 

--- a/src/main/java/com/cajaviva/cajaviva/dto/RegisterUserRequest.java
+++ b/src/main/java/com/cajaviva/cajaviva/dto/RegisterUserRequest.java
@@ -1,0 +1,13 @@
+package com.cajaviva.cajaviva.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterUserRequest(
+        @NotBlank @Size(max = 100) String name,
+        @NotBlank @Size(max = 100) String lastName,
+        @NotBlank @Email @Size(max = 150) String email,
+        @NotBlank @Size(min = 8, max = 72) String password
+) {
+}

--- a/src/main/java/com/cajaviva/cajaviva/entity/AuthUser.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/AuthUser.java
@@ -1,20 +1,36 @@
 package com.cajaviva.cajaviva.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public class User {
+@Entity
+@Table(name = "users")
+public class AuthUser {
 
+    @Id
     private UUID id;
+
+    @Column(name = "name", nullable = false)
     private String name;
-    private String lastName;
+
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
-    @JsonIgnore
+
+    @Column(name = "password_digest", nullable = false)
     private String passwordDigest;
+
+    @Column(name = "active", nullable = false)
     private boolean active;
+
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     public UUID getId() {
@@ -31,14 +47,6 @@ public class User {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
     }
 
     public String getEmail() {

--- a/src/main/java/com/cajaviva/cajaviva/entity/FinancialTransaction.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/FinancialTransaction.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "financial_transactions")
+@Table(name = "FinancialTransactions")
 public class FinancialTransaction {
 
     @Id

--- a/src/main/java/com/cajaviva/cajaviva/entity/LiquidityProjection.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/LiquidityProjection.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "liquidity_projections")
+@Table(name = "LiquidityProjections")
 public class LiquidityProjection {
 
     @Id

--- a/src/main/java/com/cajaviva/cajaviva/entity/RecurrentTransaction.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/RecurrentTransaction.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "recurrent_transactions")
+@Table(name = "RecurrentTransactions")
 public class RecurrentTransaction {
 
     @Id

--- a/src/main/java/com/cajaviva/cajaviva/entity/RefreshToken.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/RefreshToken.java
@@ -1,0 +1,93 @@
+package com.cajaviva.cajaviva.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 128)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "replaced_by_token_hash", length = 128)
+    private String replacedByTokenHash;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public void setTokenHash(String tokenHash) {
+        this.tokenHash = tokenHash;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public LocalDateTime getRevokedAt() {
+        return revokedAt;
+    }
+
+    public void setRevokedAt(LocalDateTime revokedAt) {
+        this.revokedAt = revokedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getReplacedByTokenHash() {
+        return replacedByTokenHash;
+    }
+
+    public void setReplacedByTokenHash(String replacedByTokenHash) {
+        this.replacedByTokenHash = replacedByTokenHash;
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/entity/UserAccess.java
+++ b/src/main/java/com/cajaviva/cajaviva/entity/UserAccess.java
@@ -1,40 +1,42 @@
 package com.cajaviva.cajaviva.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "user_access")
+@Table(name = "UserAccesses")
 public class UserAccess {
 
     @Id
+    @GeneratedValue
     private UUID id;
-
-    @Column(name = "person_id")
-    private UUID personId;
 
     @Column(name = "account_id")
     private UUID accountId;
 
     @Column(name = "role")
-    private String role;
+    private Integer role;
 
     @Column(name = "user_id")
     private UUID userId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     // Getters y setters
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
-    public UUID getPersonId() { return personId; }
-    public void setPersonId(UUID personId) { this.personId = personId; }
-
     public UUID getAccountId() { return accountId; }
     public void setAccountId(UUID accountId) { this.accountId = accountId; }
 
-    public String getRole() { return role; }
-    public void setRole(String role) { this.role = role; }
+    public Integer getRole() { return role; }
+    public void setRole(Integer role) { this.role = role; }
 
     public UUID getUserId() { return userId; }
     public void setUserId(UUID userId) { this.userId = userId; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 }

--- a/src/main/java/com/cajaviva/cajaviva/exception/AuthenticationFailedException.java
+++ b/src/main/java/com/cajaviva/cajaviva/exception/AuthenticationFailedException.java
@@ -1,0 +1,7 @@
+package com.cajaviva.cajaviva.exception;
+
+public class AuthenticationFailedException extends RuntimeException {
+    public AuthenticationFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cajaviva/cajaviva/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.cajaviva.cajaviva.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,7 +12,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
 
 @RestControllerAdvice
@@ -33,20 +33,26 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessValidationException.class)
     public ResponseEntity<ApiErrorResponse> handleBusinessValidation(BusinessValidationException exception) {
-        logger.warn("Error de validación: {}", exception.getMessage());
+        logger.warn("Error de validacion: {}", exception.getMessage());
         return buildResponse(exception.getMessage(), "BUSINESS_VALIDATION_ERROR", HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AuthenticationFailedException.class)
+    public ResponseEntity<ApiErrorResponse> handleAuthenticationFailed(AuthenticationFailedException exception) {
+        logger.warn("Error de autenticacion: {}", exception.getMessage());
+        return buildResponse(exception.getMessage(), "UNAUTHORIZED", HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
-        logger.warn("Validación de request fallida: {}", exception.getMessage());
-        return buildResponse("La validación del cuerpo de la solicitud falló.", "REQUEST_VALIDATION_ERROR", HttpStatus.BAD_REQUEST);
+        logger.warn("Validacion de request fallida: {}", exception.getMessage());
+        return buildResponse("La validacion del cuerpo de la solicitud fallo.", "REQUEST_VALIDATION_ERROR", HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ApiErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException exception) {
         String message = exception.getMostSpecificCause().getMessage();
-        logger.error("Violación de integridad de datos: {}", message);
+        logger.error("Violacion de integridad de datos: {}", message);
 
         if (message.contains("Duplicate entry")) {
             return buildResponse("El recurso ya existe (duplicado).", "DUPLICATE_RESOURCE", HttpStatus.CONFLICT);
@@ -54,13 +60,13 @@ public class GlobalExceptionHandler {
         if (message.contains("foreign key constraint")) {
             return buildResponse("El recurso referenciado no existe.", "REFERENCED_RESOURCE_NOT_FOUND", HttpStatus.BAD_REQUEST);
         }
-        return buildResponse("Violación de integridad de datos.", "DATA_INTEGRITY_ERROR", HttpStatus.CONFLICT);
+        return buildResponse("Violacion de integridad de datos.", "DATA_INTEGRITY_ERROR", HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiErrorResponse> handleConstraintViolation(ConstraintViolationException exception) {
-        logger.warn("Validación de path variable fallida: {}", exception.getMessage());
-        return buildResponse("El formato del parámetro es inválido.", "INVALID_PARAMETER", HttpStatus.BAD_REQUEST);
+        logger.warn("Validacion de path variable fallida: {}", exception.getMessage());
+        return buildResponse("El formato del parametro es invalido.", "INVALID_PARAMETER", HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
@@ -72,7 +78,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiErrorResponse> handleUnexpectedException(Exception exception) {
         logger.error("Error inesperado: {} - {}", exception.getClass().getSimpleName(), exception.getMessage(), exception);
-        return buildResponse("Ocurrió un error interno inesperado.", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
+        return buildResponse("Ocurrio un error interno inesperado.", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     private ResponseEntity<ApiErrorResponse> buildResponse(String message, String code, HttpStatus status) {

--- a/src/main/java/com/cajaviva/cajaviva/repository/JPA/AuthUserRepository.java
+++ b/src/main/java/com/cajaviva/cajaviva/repository/JPA/AuthUserRepository.java
@@ -1,0 +1,11 @@
+package com.cajaviva.cajaviva.repository.JPA;
+
+import com.cajaviva.cajaviva.entity.AuthUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AuthUserRepository extends JpaRepository<AuthUser, UUID> {
+    Optional<AuthUser> findByEmailIgnoreCase(String email);
+}

--- a/src/main/java/com/cajaviva/cajaviva/repository/JPA/RefreshTokenRepository.java
+++ b/src/main/java/com/cajaviva/cajaviva/repository/JPA/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.cajaviva.cajaviva.repository.JPA;
+
+import com.cajaviva.cajaviva.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+    void deleteByUserId(UUID userId);
+    long deleteByRevokedAtIsNotNullOrExpiresAtBefore(LocalDateTime now);
+}

--- a/src/main/java/com/cajaviva/cajaviva/repository/JPA/UserAccessRepository.java
+++ b/src/main/java/com/cajaviva/cajaviva/repository/JPA/UserAccessRepository.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface UserAccessRepository extends JpaRepository<UserAccess, UUID> {
-    List<UserAccess> findByPersonId(UUID personId);
     List<UserAccess> findByAccountId(UUID accountId);
-    List<UserAccess> findByRole(String role);
+    List<UserAccess> findByRole(Integer role);
     List<UserAccess> findByUserId(UUID userId);
 }

--- a/src/main/java/com/cajaviva/cajaviva/service/RegistryService.java
+++ b/src/main/java/com/cajaviva/cajaviva/service/RegistryService.java
@@ -1,0 +1,8 @@
+package com.cajaviva.cajaviva.service;
+
+import com.cajaviva.cajaviva.dto.RegisterUserRequest;
+import com.cajaviva.cajaviva.entity.User;
+
+public interface RegistryService {
+    User registerUser(RegisterUserRequest request);
+}

--- a/src/main/java/com/cajaviva/cajaviva/service/UserAccessService.java
+++ b/src/main/java/com/cajaviva/cajaviva/service/UserAccessService.java
@@ -1,6 +1,7 @@
 package com.cajaviva.cajaviva.service;
 
 import com.cajaviva.cajaviva.entity.UserAccess;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -11,9 +12,7 @@ public interface UserAccessService {
     UserAccess update(UUID id, UserAccess userAccess);
     void delete(UUID id);
 
-    // Métodos adicionales según tu DAO/Repository
-    List<UserAccess> findByPersonId(UUID personId);
     List<UserAccess> findByAccountId(UUID accountId);
-    List<UserAccess> findByRole(String role);
-    List<UserAccess> findByUserId(UUID user_id);
+    List<UserAccess> findByRole(Integer role);
+    List<UserAccess> findByUserId(UUID userId);
 }

--- a/src/main/java/com/cajaviva/cajaviva/service/impl/RegistryServiceImpl.java
+++ b/src/main/java/com/cajaviva/cajaviva/service/impl/RegistryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.cajaviva.cajaviva.service.impl;
+
+import com.cajaviva.cajaviva.dto.RegisterUserRequest;
+import com.cajaviva.cajaviva.entity.User;
+import com.cajaviva.cajaviva.exception.ConflictException;
+import com.cajaviva.cajaviva.repository.JPA.AuthUserRepository;
+import com.cajaviva.cajaviva.service.RegistryService;
+import com.cajaviva.cajaviva.service.UserService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RegistryServiceImpl implements RegistryService {
+
+    private final UserService userService;
+    private final AuthUserRepository authUserRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public RegistryServiceImpl(UserService userService, AuthUserRepository authUserRepository, PasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.authUserRepository = authUserRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public User registerUser(RegisterUserRequest request) {
+        authUserRepository.findByEmailIgnoreCase(request.email()).ifPresent(existing -> {
+            throw new ConflictException("El correo ya esta registrado.");
+        });
+
+        User user = new User();
+        user.setName(request.name());
+        user.setLastName(request.lastName());
+        user.setEmail(request.email().trim().toLowerCase());
+        user.setPasswordDigest(passwordEncoder.encode(request.password()));
+        user.setActive(true);
+
+        return userService.create(user);
+    }
+}

--- a/src/main/java/com/cajaviva/cajaviva/service/impl/UserAccessServiceImpl.java
+++ b/src/main/java/com/cajaviva/cajaviva/service/impl/UserAccessServiceImpl.java
@@ -5,6 +5,7 @@ import com.cajaviva.cajaviva.repository.JPA.UserAccessRepository;
 import com.cajaviva.cajaviva.service.UserAccessService;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,11 +30,18 @@ public class UserAccessServiceImpl implements UserAccessService {
 
     @Override
     public UserAccess create(UserAccess userAccess) {
+        userAccess.setCreatedAt(LocalDateTime.now());
         return repository.save(userAccess);
     }
 
     @Override
     public UserAccess update(UUID id, UserAccess userAccess) {
+        UserAccess existing = findById(id);
+        if (existing != null && existing.getCreatedAt() != null) {
+            userAccess.setCreatedAt(existing.getCreatedAt());
+        } else if (userAccess.getCreatedAt() == null) {
+            userAccess.setCreatedAt(LocalDateTime.now());
+        }
         userAccess.setId(id);
         return repository.save(userAccess);
     }
@@ -44,17 +52,12 @@ public class UserAccessServiceImpl implements UserAccessService {
     }
 
     @Override
-    public List<UserAccess> findByPersonId(UUID personId) {
-        return repository.findByPersonId(personId);
-    }
-
-    @Override
     public List<UserAccess> findByAccountId(UUID accountId) {
         return repository.findByAccountId(accountId);
     }
 
     @Override
-    public List<UserAccess> findByRole(String role) {
+    public List<UserAccess> findByRole(Integer role) {
         return repository.findByRole(role);
     }
 

--- a/src/main/java/com/cajaviva/cajaviva/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/cajaviva/cajaviva/service/impl/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.cajaviva.cajaviva.entity.User;
 import com.cajaviva.cajaviva.service.UserService;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,17 +34,40 @@ public User findById(UUID id) {
 
     @Override
     public User create(User user) {
-        // Si no tiene id, generar uno nuevo
-        if (user.getId() == null) user.setId(UUID.randomUUID());
+        if (user.getId() == null) {
+            user.setId(UUID.randomUUID());
+        }
+        if (user.getLastName() == null || user.getLastName().isBlank()) {
+            user.setLastName(user.getName());
+        }
+        if (user.getPasswordDigest() == null || user.getPasswordDigest().isBlank()) {
+            throw new com.cajaviva.cajaviva.exception.BusinessValidationException("passwordDigest es requerido.");
+        }
+        user.setActive(true);
+        LocalDateTime now = LocalDateTime.now();
+        if (user.getCreatedAt() == null) {
+            user.setCreatedAt(now);
+        }
+        user.setUpdatedAt(now);
         return userDao.create(user);
     }
 
 @Override
 public User update(UUID id, User user) {
-    User updated = userDao.update(id, user);
-    if (updated == null) {
+    User existing = userDao.findById(id);
+    if (existing == null) {
         throw new com.cajaviva.cajaviva.exception.ResourceNotFoundException("User not found: " + id);
     }
+    if (user.getLastName() == null || user.getLastName().isBlank()) {
+        user.setLastName(user.getName());
+    }
+    if (user.getPasswordDigest() == null || user.getPasswordDigest().isBlank()) {
+        user.setPasswordDigest(existing.getPasswordDigest());
+    }
+    user.setActive(existing.isActive());
+    user.setCreatedAt(existing.getCreatedAt());
+    user.setUpdatedAt(LocalDateTime.now());
+    User updated = userDao.update(id, user);
     return updated;
 }
 

--- a/src/main/java/com/cajaviva/cajaviva/utilities/Conexion.java
+++ b/src/main/java/com/cajaviva/cajaviva/utilities/Conexion.java
@@ -8,9 +8,10 @@ import java.sql.Connection;
 @Component
 public class Conexion {
 
-    private DataSource dataSource = null;
+    private final DataSource dataSource;
 
-    public Conexion() {
+    public Conexion(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public Connection obtenerConexion() throws Exception {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   mvc:
     throw-exception-if-no-handler-found: true
   profiles:
-    active: h2
+    active: sqlserver
 
 springdoc:
   api-docs:
@@ -17,6 +17,19 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+security:
+  jwt:
+    issuer: cajaviva
+    audience: cajaviva-api
+    access-ttl-minutes: 15
+    refresh-ttl-days: 7
+    signing-key: ${JWT_SIGNING_KEY:01234567890123456789012345678901}
+  cookie:
+    domain: ""
+    secure: false
+    same-site: Lax
+    path: /
 
 ---
 
@@ -40,6 +53,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    properties:
+      hibernate:
+        bytecode:
+          provider: none
 
   flyway:
     enabled: false
@@ -65,9 +82,13 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: true
+    properties:
+      hibernate:
+        bytecode:
+          provider: none
 
   flyway:
-    enabled: false
+    enabled: true
 
   web:
     resources:

--- a/src/main/resources/db/migration/V2__auth_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V2__auth_refresh_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE refresh_tokens (
+    id UNIQUEIDENTIFIER DEFAULT NEWSEQUENTIALID() PRIMARY KEY,
+    user_id UNIQUEIDENTIFIER NOT NULL,
+    token_hash VARCHAR(128) NOT NULL UNIQUE,
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    replaced_by_token_hash VARCHAR(128) NULL,
+    CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES Users(id)
+);
+
+CREATE INDEX ix_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX ix_refresh_tokens_expires_at ON refresh_tokens(expires_at);

--- a/src/main/resources/db/migration/V3__align_jpa_with_schema.sql
+++ b/src/main/resources/db/migration/V3__align_jpa_with_schema.sql
@@ -1,0 +1,5 @@
+IF COL_LENGTH('RecurrentTransactions', 'status') IS NULL
+BEGIN
+    ALTER TABLE RecurrentTransactions ADD status TINYINT NULL;
+END
+GO

--- a/src/test/java/com/cajaviva/cajaviva/controller/AccountControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/AccountControllerSecurityTest.java
@@ -1,0 +1,68 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.Account;
+import com.cajaviva.cajaviva.service.AccountService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AccountController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class AccountControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean private AccountService accountService;
+    @MockBean private JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/accounts")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/accounts/user/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/accounts/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/accounts/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/accounts/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        Account account = new Account();
+        account.setId(id);
+        when(accountService.findAll()).thenReturn(List.of(account));
+        when(accountService.findByUserId(id)).thenReturn(List.of(account));
+        when(accountService.findById(id)).thenReturn(account);
+        when(accountService.create(any(Account.class))).thenReturn(account);
+        when(accountService.update(any(UUID.class), any(Account.class))).thenReturn(account);
+
+        mockMvc.perform(get("/accounts")).andExpect(status().isOk());
+        mockMvc.perform(get("/accounts/user/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/accounts/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Cuenta\",\"userId\":\"" + id + "\",\"accountType\":1,\"balance\":10}").with(csrf())).andExpect(status().isCreated());
+        mockMvc.perform(put("/accounts/" + id).contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Cuenta\",\"userId\":\"" + id + "\",\"accountType\":1,\"balance\":10}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/accounts/" + id).with(csrf())).andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/AlertControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/AlertControllerSecurityTest.java
@@ -1,0 +1,66 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.Alert;
+import com.cajaviva.cajaviva.service.AlertService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlertController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class AlertControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean AlertService alertService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/alerts")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/alerts/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/alerts/projection/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/alerts").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/alerts/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/alerts/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        Alert alert = new Alert();
+        alert.setId(id);
+        when(alertService.findAll()).thenReturn(List.of(alert));
+        when(alertService.findById(id)).thenReturn(alert);
+        when(alertService.findByLiquidityProjectionId(id)).thenReturn(List.of(alert));
+        when(alertService.create(any(Alert.class))).thenReturn(alert);
+        when(alertService.update(any(UUID.class), any(Alert.class))).thenReturn(alert);
+
+        mockMvc.perform(get("/api/alerts")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/alerts/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/alerts/projection/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/alerts").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/alerts/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/alerts/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/AuthControllerTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/AuthControllerTest.java
@@ -1,0 +1,68 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.controller.AuthController;
+import com.cajaviva.cajaviva.auth.dto.AuthResponse;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.auth.service.AuthService;
+import com.cajaviva.cajaviva.auth.service.CookieService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private CookieService cookieService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    void loginReturns200AndUserPayload() throws Exception {
+        UUID userId = UUID.randomUUID();
+        AuthResponse response = new AuthResponse(userId, "user@test.com", List.of("ROLE_USER"), LocalDateTime.now().plusMinutes(15));
+        AuthService.AuthResult result = new AuthService.AuthResult("access", "refresh", response);
+
+        when(authService.login(any())).thenReturn(result);
+        when(authService.accessTtl()).thenReturn(Duration.ofMinutes(15));
+        when(authService.refreshTtl()).thenReturn(Duration.ofDays(7));
+        doNothing().when(cookieService).addAccessCookie(any(), any(), any());
+        doNothing().when(cookieService).addRefreshCookie(any(), any(), any());
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "user@test.com",
+                                  "password": "Secret123*"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value("user@test.com"));
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/CategoryControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/CategoryControllerSecurityTest.java
@@ -1,0 +1,63 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.Category;
+import com.cajaviva.cajaviva.service.CategoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoryController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class CategoryControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean CategoryService categoryService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/categories")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/categories/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/categories").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/categories/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/categories/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        Category category = new Category();
+        category.setId(id);
+        when(categoryService.findAll()).thenReturn(List.of(category));
+        when(categoryService.findById(id)).thenReturn(category);
+        when(categoryService.create(any(Category.class))).thenReturn(category);
+        when(categoryService.update(any(UUID.class), any(Category.class))).thenReturn(category);
+
+        mockMvc.perform(get("/api/categories")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/categories/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/categories").contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Cat\",\"type\":1}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/categories/" + id).contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Cat\",\"type\":1}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/categories/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/FinancialTransactionControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/FinancialTransactionControllerSecurityTest.java
@@ -1,0 +1,66 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.FinancialTransaction;
+import com.cajaviva.cajaviva.service.FinancialTransactionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FinancialTransactionController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class FinancialTransactionControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean FinancialTransactionService financialTransactionService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/transactions")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/transactions/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/transactions/account/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/transactions").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/transactions/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/transactions/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        FinancialTransaction tx = new FinancialTransaction();
+        tx.setId(id);
+        when(financialTransactionService.findAll()).thenReturn(List.of(tx));
+        when(financialTransactionService.findById(id)).thenReturn(tx);
+        when(financialTransactionService.findByAccountId(id)).thenReturn(List.of(tx));
+        when(financialTransactionService.create(any(FinancialTransaction.class))).thenReturn(tx);
+        when(financialTransactionService.update(any(UUID.class), any(FinancialTransaction.class))).thenReturn(tx);
+
+        mockMvc.perform(get("/api/transactions")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/transactions/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/transactions/account/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/transactions").contentType(MediaType.APPLICATION_JSON).content("{\"status\":1}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/transactions/" + id).contentType(MediaType.APPLICATION_JSON).content("{\"status\":1}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/transactions/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/LiquidityProjectionControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/LiquidityProjectionControllerSecurityTest.java
@@ -1,0 +1,66 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.LiquidityProjection;
+import com.cajaviva.cajaviva.service.LiquidityProjectionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LiquidityProjectionController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class LiquidityProjectionControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean LiquidityProjectionService liquidityProjectionService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/liquidity-projections")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/liquidity-projections/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/liquidity-projections/account/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/liquidity-projections").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/liquidity-projections/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/liquidity-projections/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        LiquidityProjection p = new LiquidityProjection();
+        p.setId(id);
+        when(liquidityProjectionService.findAll()).thenReturn(List.of(p));
+        when(liquidityProjectionService.findById(id)).thenReturn(p);
+        when(liquidityProjectionService.findByAccountId(id)).thenReturn(List.of(p));
+        when(liquidityProjectionService.create(any(LiquidityProjection.class))).thenReturn(p);
+        when(liquidityProjectionService.update(any(UUID.class), any(LiquidityProjection.class))).thenReturn(p);
+
+        mockMvc.perform(get("/api/liquidity-projections")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/liquidity-projections/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/liquidity-projections/account/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/liquidity-projections").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/liquidity-projections/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/liquidity-projections/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/RecurrentTransactionControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/RecurrentTransactionControllerSecurityTest.java
@@ -1,0 +1,66 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.RecurrentTransaction;
+import com.cajaviva.cajaviva.service.RecurrentTransactionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecurrentTransactionController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class RecurrentTransactionControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean RecurrentTransactionService recurrentTransactionService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/recurrent-transactions")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/recurrent-transactions/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/recurrent-transactions/account/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/recurrent-transactions").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/recurrent-transactions/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/recurrent-transactions/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        RecurrentTransaction tx = new RecurrentTransaction();
+        tx.setId(id);
+        when(recurrentTransactionService.findAll()).thenReturn(List.of(tx));
+        when(recurrentTransactionService.findById(id)).thenReturn(tx);
+        when(recurrentTransactionService.findByAccountId(id)).thenReturn(List.of(tx));
+        when(recurrentTransactionService.create(any(RecurrentTransaction.class))).thenReturn(tx);
+        when(recurrentTransactionService.update(any(UUID.class), any(RecurrentTransaction.class))).thenReturn(tx);
+
+        mockMvc.perform(get("/api/recurrent-transactions")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/recurrent-transactions/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/recurrent-transactions/account/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/recurrent-transactions").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/recurrent-transactions/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/recurrent-transactions/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/RegistryControllerTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/RegistryControllerTest.java
@@ -1,0 +1,59 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.dto.RegisterUserRequest;
+import com.cajaviva.cajaviva.entity.User;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.service.RegistryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RegistryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RegistryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistryService registryService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    void registerUserReturns201() throws Exception {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setName("Ana");
+        user.setLastName("Lopez");
+        user.setEmail("ana@test.com");
+        when(registryService.registerUser(any(RegisterUserRequest.class))).thenReturn(user);
+
+        mockMvc.perform(post("/registries/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Ana",
+                                  "lastName": "Lopez",
+                                  "email": "ana@test.com",
+                                  "password": "Secret123*"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(user.getId().toString()))
+                .andExpect(jsonPath("$.email").value("ana@test.com"));
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/UserAccessControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/UserAccessControllerSecurityTest.java
@@ -1,0 +1,69 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.UserAccess;
+import com.cajaviva.cajaviva.service.UserAccessService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserAccessController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class UserAccessControllerSecurityTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean UserAccessService userAccessService;
+    @MockBean JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/api/user-accesses")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/user-accesses/user/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/user-accesses/account/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/user-accesses/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/user-accesses").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/user-accesses/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/api/user-accesses/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        UserAccess ua = new UserAccess();
+        ua.setId(id);
+        when(userAccessService.findAll()).thenReturn(List.of(ua));
+        when(userAccessService.findByUserId(id)).thenReturn(List.of(ua));
+        when(userAccessService.findByAccountId(id)).thenReturn(List.of(ua));
+        when(userAccessService.findById(id)).thenReturn(ua);
+        when(userAccessService.create(any(UserAccess.class))).thenReturn(ua);
+        when(userAccessService.update(any(UUID.class), any(UserAccess.class))).thenReturn(ua);
+
+        mockMvc.perform(get("/api/user-accesses")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/user-accesses/user/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/user-accesses/account/" + id)).andExpect(status().isOk());
+        mockMvc.perform(get("/api/user-accesses/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/user-accesses").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/api/user-accesses/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/api/user-accesses/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/controller/UserControllerSecurityTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/controller/UserControllerSecurityTest.java
@@ -1,0 +1,71 @@
+package com.cajaviva.cajaviva.controller;
+
+import com.cajaviva.cajaviva.auth.security.RestAccessDeniedHandler;
+import com.cajaviva.cajaviva.auth.security.RestAuthenticationEntryPoint;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.config.SecurityConfig;
+import com.cajaviva.cajaviva.entity.User;
+import com.cajaviva.cajaviva.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import({SecurityConfig.class, RestAuthenticationEntryPoint.class, RestAccessDeniedHandler.class})
+class UserControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    void unauthenticatedEndpointsReturn401() throws Exception {
+        UUID id = UUID.randomUUID();
+        mockMvc.perform(get("/users")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/users/" + id)).andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/users").contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/users/" + id).contentType(MediaType.APPLICATION_JSON).content("{}").with(csrf())).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/users/" + id).with(csrf())).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void authenticatedEndpointsAreAccessible() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(userService.findAll()).thenReturn(List.of(new User()));
+        User user = new User();
+        user.setId(id);
+        when(userService.findById(id)).thenReturn(user);
+        when(userService.create(any(User.class))).thenReturn(user);
+        when(userService.update(any(UUID.class), any(User.class))).thenReturn(user);
+
+        mockMvc.perform(get("/users")).andExpect(status().isOk());
+        mockMvc.perform(get("/users/" + id)).andExpect(status().isOk());
+        mockMvc.perform(post("/users").contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"A\",\"email\":\"a@a.com\"}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(put("/users/" + id).contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"A\",\"email\":\"a@a.com\"}").with(csrf())).andExpect(status().isOk());
+        mockMvc.perform(delete("/users/" + id).with(csrf())).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/dao/impl/UserDaoTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/dao/impl/UserDaoTest.java
@@ -5,7 +5,9 @@ import com.cajaviva.cajaviva.utilities.Conexion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,7 +25,7 @@ class UserDaoTest {
         private final Connection connection;
 
         public StubConexion(Connection connection) {
-            super();
+            super(mock(DataSource.class));
             this.connection = connection;
         }
 
@@ -52,6 +54,7 @@ class UserDaoTest {
         when(rs.next()).thenReturn(true, true, false);
         when(rs.getString("id")).thenReturn(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         when(rs.getString("name")).thenReturn("Alice", "Bob");
+        when(rs.getString("last_name")).thenReturn("A", "B");
         when(rs.getString("email")).thenReturn("alice@test.com", "bob@test.com");
 
         List<User> result = userDao.findAll();
@@ -68,6 +71,7 @@ class UserDaoTest {
         when(rs.next()).thenReturn(true);
         when(rs.getString("id")).thenReturn(id.toString());
         when(rs.getString("name")).thenReturn("Charlie");
+        when(rs.getString("last_name")).thenReturn("C");
         when(rs.getString("email")).thenReturn("charlie@test.com");
 
         User result = userDao.findById(id);
@@ -91,7 +95,12 @@ class UserDaoTest {
     void testCreateGeneratesIdIfNull() throws Exception {
         User user = new User();
         user.setName("David");
+        user.setLastName("Miller");
         user.setEmail("david@test.com");
+        user.setPasswordDigest("hash");
+        user.setActive(true);
+        user.setCreatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
 
         User result = userDao.create(user);
 
@@ -105,7 +114,11 @@ class UserDaoTest {
         UUID id = UUID.randomUUID();
         User user = new User();
         user.setName("Eva");
+        user.setLastName("Stone");
         user.setEmail("eva@test.com");
+        user.setPasswordDigest("hash2");
+        user.setActive(true);
+        user.setUpdatedAt(LocalDateTime.now());
 
         User result = userDao.update(id, user);
 

--- a/src/test/java/com/cajaviva/cajaviva/service/AuthServiceTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/service/AuthServiceTest.java
@@ -1,0 +1,116 @@
+package com.cajaviva.cajaviva.service;
+
+import com.cajaviva.cajaviva.auth.config.JwtProperties;
+import com.cajaviva.cajaviva.auth.dto.LoginRequest;
+import com.cajaviva.cajaviva.auth.service.AuthService;
+import com.cajaviva.cajaviva.auth.service.JwtService;
+import com.cajaviva.cajaviva.auth.service.RefreshTokenService;
+import com.cajaviva.cajaviva.entity.AuthUser;
+import com.cajaviva.cajaviva.entity.RefreshToken;
+import com.cajaviva.cajaviva.exception.AuthenticationFailedException;
+import com.cajaviva.cajaviva.repository.JPA.AuthUserRepository;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest {
+
+    private AuthUserRepository authUserRepository;
+    private JwtService jwtService;
+    private RefreshTokenService refreshTokenService;
+    private PasswordEncoder passwordEncoder;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authUserRepository = mock(AuthUserRepository.class);
+        jwtService = mock(JwtService.class);
+        refreshTokenService = mock(RefreshTokenService.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+
+        JwtProperties props = new JwtProperties();
+        props.setAccessTtlMinutes(15);
+        props.setRefreshTtlDays(7);
+        props.setIssuer("cajaviva");
+        props.setAudience("cajaviva-api");
+        props.setSigningKey("01234567890123456789012345678901");
+
+        authService = new AuthService(authUserRepository, jwtService, refreshTokenService, passwordEncoder, props);
+    }
+
+    @Test
+    void loginSuccessReturnsTokensAndResponse() {
+        AuthUser user = activeUser();
+        when(authUserRepository.findByEmailIgnoreCase("user@test.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("pass12345", user.getPasswordDigest())).thenReturn(true);
+        when(jwtService.generateAccessToken(user.getId(), user.getEmail())).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(user.getId())).thenReturn("refresh-token");
+
+        AuthService.AuthResult result = authService.login(new LoginRequest("user@test.com", "pass12345"));
+
+        assertNotNull(result);
+        assertEquals("access-token", result.accessToken());
+        assertEquals("refresh-token", result.refreshToken());
+        assertEquals(user.getId(), result.response().userId());
+        verify(refreshTokenService, times(1)).save(eq(user.getId()), eq("refresh-token"), any(LocalDateTime.class));
+    }
+
+    @Test
+    void loginWithBadPasswordThrowsAuthenticationFailed() {
+        AuthUser user = activeUser();
+        when(authUserRepository.findByEmailIgnoreCase("user@test.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", user.getPasswordDigest())).thenReturn(false);
+
+        assertThrows(AuthenticationFailedException.class, () -> authService.login(new LoginRequest("user@test.com", "wrong")));
+    }
+
+    @Test
+    void refreshSuccessRotatesToken() {
+        UUID userId = UUID.randomUUID();
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn(userId.toString());
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setRevokedAt(null);
+        refreshToken.setExpiresAt(LocalDateTime.now().plusDays(1));
+
+        AuthUser user = activeUser();
+        user.setId(userId);
+
+        when(jwtService.parseAndValidate("refresh-old")).thenReturn(claims);
+        when(jwtService.extractTokenType(claims)).thenReturn(JwtService.TokenType.REFRESH);
+        when(refreshTokenService.findByRawToken("refresh-old")).thenReturn(Optional.of(refreshToken));
+        when(refreshTokenService.isUsable(refreshToken)).thenReturn(true);
+        when(authUserRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(jwtService.generateAccessToken(userId, user.getEmail())).thenReturn("access-new");
+        when(jwtService.generateRefreshToken(userId)).thenReturn("refresh-new");
+
+        AuthService.AuthResult result = authService.refresh("refresh-old");
+
+        assertEquals("access-new", result.accessToken());
+        assertEquals("refresh-new", result.refreshToken());
+        verify(refreshTokenService, times(1)).revoke(refreshToken, "refresh-new");
+    }
+
+    @Test
+    void refreshWithoutTokenThrowsAuthenticationFailed() {
+        assertThrows(AuthenticationFailedException.class, () -> authService.refresh(null));
+    }
+
+    private AuthUser activeUser() {
+        AuthUser user = new AuthUser();
+        user.setId(UUID.randomUUID());
+        user.setEmail("user@test.com");
+        user.setPasswordDigest("$2a$10$abc");
+        user.setActive(true);
+        return user;
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/service/RegistryServiceTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/service/RegistryServiceTest.java
@@ -1,0 +1,63 @@
+package com.cajaviva.cajaviva.service;
+
+import com.cajaviva.cajaviva.dto.RegisterUserRequest;
+import com.cajaviva.cajaviva.entity.AuthUser;
+import com.cajaviva.cajaviva.entity.User;
+import com.cajaviva.cajaviva.exception.ConflictException;
+import com.cajaviva.cajaviva.repository.JPA.AuthUserRepository;
+import com.cajaviva.cajaviva.service.impl.RegistryServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class RegistryServiceTest {
+
+    private UserService userService;
+    private AuthUserRepository authUserRepository;
+    private PasswordEncoder passwordEncoder;
+    private RegistryServiceImpl registryService;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        authUserRepository = mock(AuthUserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        registryService = new RegistryServiceImpl(userService, authUserRepository, passwordEncoder);
+    }
+
+    @Test
+    void registerUserCreatesUserWithEncodedPassword() {
+        RegisterUserRequest request = new RegisterUserRequest("Ana", "Lopez", "Ana@Test.com", "Secret123*");
+        when(authUserRepository.findByEmailIgnoreCase("Ana@Test.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("Secret123*")).thenReturn("encoded-password");
+        when(userService.create(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setId(UUID.randomUUID());
+            return user;
+        });
+
+        User result = registryService.registerUser(request);
+
+        assertNotNull(result.getId());
+        assertEquals("ana@test.com", result.getEmail());
+        assertTrue(result.isActive());
+        verify(userService, times(1)).create(any(User.class));
+    }
+
+    @Test
+    void registerUserWithDuplicatedEmailThrowsConflict() {
+        RegisterUserRequest request = new RegisterUserRequest("Ana", "Lopez", "ana@test.com", "Secret123*");
+        AuthUser existing = new AuthUser();
+        when(authUserRepository.findByEmailIgnoreCase("ana@test.com")).thenReturn(Optional.of(existing));
+
+        assertThrows(ConflictException.class, () -> registryService.registerUser(request));
+        verify(userService, never()).create(any(User.class));
+    }
+}

--- a/src/test/java/com/cajaviva/cajaviva/service/UserAccessServiceTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/service/UserAccessServiceTest.java
@@ -73,14 +73,18 @@ class UserAccessServiceTest {
     @Test
     void testUpdate() {
         UUID id = UUID.randomUUID();
+        UserAccess existing = new UserAccess();
+        existing.setId(id);
         UserAccess access = new UserAccess();
         access.setId(id);
 
+        when(repository.findById(id)).thenReturn(Optional.of(existing));
         when(repository.save(any(UserAccess.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         UserAccess result = service.update(id, access);
 
         assertEquals(id, result.getId());
+        verify(repository, times(1)).findById(id);
         verify(repository, times(1)).save(access);
     }
 
@@ -91,18 +95,6 @@ class UserAccessServiceTest {
         service.delete(id);
 
         verify(repository, times(1)).deleteById(id);
-    }
-
-    @Test
-    void testFindByPersonId() {
-        UUID personId = UUID.randomUUID();
-        List<UserAccess> accesses = Arrays.asList(new UserAccess(), new UserAccess());
-        when(repository.findByPersonId(personId)).thenReturn(accesses);
-
-        List<UserAccess> result = service.findByPersonId(personId);
-
-        assertEquals(2, result.size());
-        verify(repository, times(1)).findByPersonId(personId);
     }
 
     @Test
@@ -119,7 +111,7 @@ class UserAccessServiceTest {
 
     @Test
     void testFindByRole() {
-        String role = "ADMIN";
+        Integer role = 1;
         List<UserAccess> accesses = Arrays.asList(new UserAccess(), new UserAccess());
         when(repository.findByRole(role)).thenReturn(accesses);
 

--- a/src/test/java/com/cajaviva/cajaviva/service/UserServiceTest.java
+++ b/src/test/java/com/cajaviva/cajaviva/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import com.cajaviva.cajaviva.service.impl.UserServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -61,6 +62,10 @@ class UserServiceTest {
     @Test
     void testCreateGeneratesIdIfNull() {
         User user = new User();
+        user.setName("Test");
+        user.setLastName("User");
+        user.setEmail("test@correo.com");
+        user.setPasswordDigest("hash");
         when(userDao.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         User result = service.create(user);
@@ -73,6 +78,10 @@ class UserServiceTest {
     void testCreateWithExistingId() {
         User user = new User();
         user.setId(UUID.randomUUID());
+        user.setName("Test");
+        user.setLastName("User");
+        user.setEmail("test@correo.com");
+        user.setPasswordDigest("hash");
         when(userDao.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         User result = service.create(user);
@@ -84,26 +93,36 @@ class UserServiceTest {
     @Test
     void testUpdateExisting() {
         UUID id = UUID.randomUUID();
+        User existing = new User();
+        existing.setId(id);
+        existing.setPasswordDigest("existing-hash");
+        existing.setCreatedAt(LocalDateTime.now().minusDays(1));
+        existing.setActive(true);
+
         User user = new User();
         user.setId(id);
+        user.setName("Updated");
+        user.setEmail("updated@correo.com");
 
+        when(userDao.findById(id)).thenReturn(existing);
         when(userDao.update(eq(id), any(User.class))).thenReturn(user);
 
         User result = service.update(id, user);
 
         assertEquals(id, result.getId());
-        verify(userDao, times(1)).update(id, user);
+        verify(userDao, times(1)).findById(id);
+        verify(userDao, times(1)).update(eq(id), any(User.class));
     }
 
     @Test
     void testUpdateNotFoundThrowsException() {
         UUID id = UUID.randomUUID();
         User user = new User();
-
-        when(userDao.update(eq(id), any(User.class))).thenReturn(null);
+        when(userDao.findById(id)).thenReturn(null);
 
         assertThrows(ResourceNotFoundException.class, () -> service.update(id, user));
-        verify(userDao, times(1)).update(id, user);
+        verify(userDao, times(1)).findById(id);
+        verify(userDao, never()).update(eq(id), any(User.class));
     }
 
     @Test

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
## 🚀 Resumen

Este PR implementa autenticación completa con **JWT en cookies seguras** y protección de endpoints con **Spring Security**, además de agregar flujo de registro público de usuarios, documentación de autenticación en Swagger/OpenAPI y cobertura de pruebas para auth/registro y acceso a endpoints protegidos.

---

## ✅ Qué se implementó

### 1) Seguridad y autenticación JWT por cookie
- Se agregó configuración de seguridad en `SecurityConfig` con:
  - `SecurityFilterChain` stateless
  - CORS explícito
  - CSRF con `CookieCsrfTokenRepository`
  - Manejo centralizado de `401/403` (`RestAuthenticationEntryPoint`, `RestAccessDeniedHandler`)
- Se creó `JwtAuthenticationFilter` para extraer y validar JWT desde cookie.
- Se implementó módulo `auth` con:
  - `AuthController`
  - `AuthService`
  - `JwtService`
  - `CookieService`
  - `RefreshTokenService`
- Endpoints auth:
  - `POST /auth/login`
  - `POST /auth/refresh`
  - `POST /auth/logout`
  - `GET /auth/me`
- Estrategia Access + Refresh token con cookies:
  - `CV_ACCESS_TOKEN`
  - `CV_REFRESH_TOKEN`

### 2) Persistencia para autenticación y refresh tokens
- Se agregó entidad/repositorio para usuario autenticable (`AuthUser`, `AuthUserRepository`).
- Se agregó entidad/repositorio de refresh tokens (`RefreshToken`, `RefreshTokenRepository`).
- Migraciones:
  - `V2__auth_refresh_tokens.sql`
  - `V3__align_jpa_with_schema.sql`

### 3) Registro de usuarios público
- Nuevo endpoint público para registro:
  - `POST /registries/users`
- Nuevos componentes:
  - `RegistryController`
  - `RegistryService` + `RegistryServiceImpl`
  - `RegisterUserRequest`
- Se respeta separación por capas y se mantiene el endpoint de `users` para administración/uso autenticado.

### 4) Swagger / OpenAPI
- Se actualizó `OpenApiConfig` para documentar esquema de seguridad y flujo de autenticación.
- Se documentó el uso de cookies, refresh y logout para consumidores de API.

### 5) Ajustes de compatibilidad y estabilidad
- `pom.xml` actualizado con dependencias de seguridad/JWT y ajustes de testing (Mockito/ByteBuddy).
- Ajustes en entidades y servicios relacionados con auth y user access.
- Ajustes en `application.yml` (perfiles y seguridad).

---

## 🧪 Pruebas agregadas / actualizadas

### Nuevas pruebas
- Auth:
  - `AuthControllerTest`
  - `AuthServiceTest`
- Registro:
  - `RegistryControllerTest`
  - `RegistryServiceTest`
- Seguridad por controlador (endpoints protegidos):
  - `UserControllerSecurityTest`
  - `AccountControllerSecurityTest`
  - `CategoryControllerSecurityTest`
  - `AlertControllerSecurityTest`
  - `FinancialTransactionControllerSecurityTest`
  - `RecurrentTransactionControllerSecurityTest`
  - `LiquidityProjectionControllerSecurityTest`
  - `UserAccessControllerSecurityTest`

### Pruebas ajustadas
- `UserDaoTest`
- `UserAccessServiceTest`
- `UserServiceTest`

---

## 📌 Notas para revisión

- Este PR incluye cambios grandes (auth + seguridad + migraciones + tests), por lo que se recomienda revisar por bloques:
  1. `config/security` + `auth/*`
  2. migraciones y entidades auth
  3. registro público
  4. tests
- En entornos donde ya se ejecutó una versión previa de `V3`, puede requerirse `flyway repair` para alinear checksum del historial.

---

## ▶️ Validación local sugerida

1. Ejecutar migraciones y arrancar app.
2. Probar flujo completo:
   - registro → login → endpoint protegido → refresh → logout
3. Ejecutar tests:
   - `./mvnw test`