### PR TITLE
fix: remove BOM from CategoryController.java

### DIFF
--- a/src/main/java/com/cajaviva/cajaviva/controller/CategoryController.java
+++ b/src/main/java/com/cajaviva/cajaviva/controller/CategoryController.java
@@ -1,4 +1,4 @@
-﻿package com.cajaviva.cajaviva.controller;
+package com.cajaviva.cajaviva.controller;
 
 import com.cajaviva.cajaviva.controller.dto.CategoryUpsertRequest;
 import com.cajaviva.cajaviva.entity.Category;


### PR DESCRIPTION
Se elimina el BOM (Byte Order Mark) del archivo CategoryController.java que impedia la compilacion con Java.